### PR TITLE
Fixed typographical error, changed archetecture to architecture in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Near future
 
 ##Architecture
 
-We follow the [lambda architectural model](http://en.wikipedia.org/wiki/Lambda_architecture) as embodies in the DASE archetecture and tool set. Streaming input comes through the PreditionIO SDKs (or optionally files), which is turned immediately into user history used to make near real time recommendations. The delay in creating this usable user history is minimal--on the order of a seconds. Recommendations are returned in real time. The predictive models are calculated in the background based on all collected data and is updated as often as requested with no server downtime.
+We follow the [lambda architectural model](http://en.wikipedia.org/wiki/Lambda_architecture) as embodies in the DASE architecture and tool set. Streaming input comes through the PreditionIO SDKs (or optionally files), which is turned immediately into user history used to make near real time recommendations. The delay in creating this usable user history is minimal--on the order of a seconds. Recommendations are returned in real time. The predictive models are calculated in the background based on all collected data and is updated as often as requested with no server downtime.
 
 The actual components of the architecture are chosen for their speed, reliability, scalability, and high-level of support. They are the at the forefront in their class:
 


### PR DESCRIPTION
@pferrel, I've corrected a typographical error in the documentation of the [template-scala-parallel-universal-recommendation](https://github.com/pferrel/template-scala-parallel-universal-recommendation) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
